### PR TITLE
Added Trajectory initializer function for strings

### DIFF
--- a/src/Trajectory.cpp
+++ b/src/Trajectory.cpp
@@ -194,12 +194,7 @@ void Trajectory::InitFromChunksList(const std::list<Chunk>&chunkslist0) {
 }
 
 
-Trajectory::Trajectory(const std::list<Chunk>& chunkslist0) {
-    InitFromChunksList(chunkslist0);
-}
-
-
-Trajectory::Trajectory(const std::string& trajectorystring) {
+void Trajectory::InitFromString(const std::string& trajectorystring) {
     std::string buff;
     std::istringstream iss(trajectorystring);
     int dimension;
@@ -221,6 +216,16 @@ Trajectory::Trajectory(const std::string& trajectorystring) {
         }
     }
     InitFromChunksList(chunkslist0);
+}
+
+
+Trajectory::Trajectory(const std::list<Chunk>& chunkslist0) {
+    InitFromChunksList(chunkslist0);
+}
+
+
+Trajectory::Trajectory(const std::string& trajectorystring) {
+    InitFromString(trajectorystring);
 }
 
 

--- a/src/Trajectory.h
+++ b/src/Trajectory.h
@@ -59,6 +59,7 @@ public:
     Trajectory(){
     }
     void InitFromChunksList(const std::list<Chunk>&chunkslist);
+    void InitFromString(const std::string& trajectorystring);
 
     int dimension;
     dReal duration;


### PR DESCRIPTION
Previously a Trajectory could be initialized after construction using ``InitFromChunksList``, but there was no ``InitFromString``. This simple PR allows post-constructor initialization from strings.