### PR TITLE
InterpolateViapoints: Adjusted Time Interval for non uniformly spaced points

### DIFF
--- a/src/python/Utilities.py
+++ b/src/python/Utilities.py
@@ -6,7 +6,7 @@ def InterpolateViapoints(path):
     nviapoints = len(path[0,:])
     tv = linspace(0,1,nviapoints)
     for i in range(nviapoints-1):
-        tv[i+1] = tv[i]+np.linalg.norm(path[:,i]-path[:,i+1])
+        tv[i+1] = tv[i]+linalg.norm(path[:,i]-path[:,i+1])
     tcklist = []
     for idof in range(0,path.shape[0]):
         tcklist.append(interpolate.splrep(tv,path[idof,:],s=0))

--- a/src/python/Utilities.py
+++ b/src/python/Utilities.py
@@ -5,6 +5,8 @@ import Trajectory
 def InterpolateViapoints(path):
     nviapoints = len(path[0,:])
     tv = linspace(0,1,nviapoints)
+    for i in range(nviapoints-1):
+        tv[i+1] = tv[i]+np.linalg.norm(path[:,i]-path[:,i+1])
     tcklist = []
     for idof in range(0,path.shape[0]):
         tcklist.append(interpolate.splrep(tv,path[idof,:],s=0))


### PR DESCRIPTION
When interpolating between viapoints it seems that you assume implicitly that the points have equal distance between them. I ran into problems when the points did not have equal distance. I constructed a minimal example, where the default interpolation in Utilities was leading to a path which was not dynamically feasible (in red). Viapoints are in black. One possible solution would be to adjust the timing according to the actual distance between points. This interpolation leads to a dynamically feasible path (in green) and seems much smoother than the original interpolation. I am considering here a point robot moving through a force field so that it loses briefly small-time controllability during execution inside the force field.

(red path:) 
Interpolate Viapoints Default TOPP VIP failure
(green path:)
Interpolate Viapoints Adjust TOPP VIP solution: 0.0 1.18485735598
 
![topp3](https://cloud.githubusercontent.com/assets/1220541/17312428/95456ef6-5820-11e6-96a2-e98dd6831ddb.png)

script to reproduce results: https://raw.githubusercontent.com/orthez/openrave-forcefields/master/topp/test_topp_interpolation.py